### PR TITLE
Add new line after prediction header

### DIFF
--- a/SparseConvNetCUDA.cu
+++ b/SparseConvNetCUDA.cu
@@ -229,7 +229,7 @@ void SparseConvNetCUDA::processDatasetRepeatTest(SpatiallySparseDataset &dataset
     if (!predictionsFilename.empty()) {
       std::cout << predictionsFilename << std::endl;
       std::ofstream f(predictionsFilename.c_str());
-      f<<header;
+      f << header << std::endl;
       for (int i=0;i<dataset.pictures.size();++i) {
         f << dataset.pictures[i]->identify();
         if (dataset.type!=UNLABELEDBATCH)


### PR DESCRIPTION
Was absent for the plankton configuration. If it was present for the others, then it's the plankton header that needs to be changed.

Let me know